### PR TITLE
fix: Resolve TypeScript error in NewsletterSubscriptionComponent

### DIFF
--- a/fruit-shop/src/app/components/newsletter-subscription/newsletter-subscription.component.ts
+++ b/fruit-shop/src/app/components/newsletter-subscription/newsletter-subscription.component.ts
@@ -7,7 +7,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms'; // Import F
   styleUrls: ['./newsletter-subscription.component.scss']
 })
 export class NewsletterSubscriptionComponent implements OnInit {
-  newsletterForm: FormGroup;
+  newsletterForm!: FormGroup;
   submitted = false;
 
   constructor(private formBuilder: FormBuilder) { }


### PR DESCRIPTION
I corrected the 'Property 'newsletterForm' has no initializer' error in newsletter-subscription.component.ts by adding the definite assignment assertion operator (`!`) to the newsletterForm property. This asserts that the property will be initialized by ngOnInit.

Note: Verification of this change via `ng build` was hindered by a persistent environment issue where the Angular CLI could not locate the '@angular-devkit/build-angular' package. This is believed to be an issue with the build environment rather than the committed code changes.