### PR TITLE
Here's an update on the CheckoutPageComponent:

### DIFF
--- a/fruit-shop/src/app/pages/checkout-page/checkout-page.component.html
+++ b/fruit-shop/src/app/pages/checkout-page/checkout-page.component.html
@@ -120,7 +120,7 @@
 <div class="form-section shipping-address-section">
       <h4>Shipping Address</h4>
       <div class="form-group form-check">
-        <input type="checkbox" id="sameAsBilling" class="form-check-input" [(ngModel)]="shippingSameAsBilling" (ngModelChange)="onShippingSameAsBillingChange()" [formControl]="null"> <!-- Use [formControl]="null" if it is not part of any reactive form -->
+        <input type="checkbox" id="sameAsBilling" class="form-check-input" [(ngModel)]="shippingSameAsBilling" (ngModelChange)="onShippingSameAsBillingChange()">
         <label class="form-check-label" for="sameAsBilling">Shipping address is the same as my billing address</label>
       </div>
 
@@ -198,11 +198,11 @@
 
       <div class="payment-method-options">
         <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="paymentMethod" id="paymentCreditCard" value="creditCard" checked (change)="selectedPaymentMethod='creditCard'" [formControl]="null">
+          <input class="form-check-input" type="radio" name="paymentMethod" id="paymentCreditCard" value="creditCard" checked (change)="selectedPaymentMethod='creditCard'">
           <label class="form-check-label" for="paymentCreditCard">Credit / Debit Card</label>
         </div>
         <div class="form-check form-check-inline">
-          <input class="form-check-input" type="radio" name="paymentMethod" id="paymentCOD" value="cod" (change)="selectedPaymentMethod='cod'" [formControl]="null">
+          <input class="form-check-input" type="radio" name="paymentMethod" id="paymentCOD" value="cod" (change)="selectedPaymentMethod='cod'">
           <label class="form-check-label" for="paymentCOD">Cash on Delivery (COD)</label>
         </div>
       </div>

--- a/fruit-shop/src/app/pages/checkout-page/checkout-page.component.scss
+++ b/fruit-shop/src/app/pages/checkout-page/checkout-page.component.scss
@@ -104,7 +104,6 @@
   font-size: 0.9em;
 }
 .item-actions .btn-remove:hover {
-  color: darken(var(--accent-color, #ff9800), 10%); /* This will need SCSS var fix if not using filter */
   /* Using a CSS filter for simplicity as SCSS var fix is more involved here */
   filter: brightness(0.8);
 }


### PR DESCRIPTION
I've resolved some compilation errors that were occurring:

1.  **SCSS Error:**
    *   I corrected an issue in `checkout-page.component.scss`. The Sass `darken()` function was being used incorrectly with a CSS variable for the `.item-actions .btn-remove:hover` style.
    *   I removed the `darken()` call. The existing `filter: brightness(0.8)` CSS rule will now handle the hover effect for the text color.

2.  **HTML Template Type Errors:**
    *   I removed incorrect `[formControl]="null"` attributes from three input elements in `checkout-page.component.html`:
        *   The "Shipping address is the same as my billing address" checkbox (`id="sameAsBilling"`).
        *   The "Credit / Debit Card" radio button (`id="paymentCreditCard"`).
        *   The "Cash on Delivery (COD)" radio button (`id="paymentCOD"`).
    *   These elements are managed by `[(ngModel)]` or direct event bindings and aren't part of a reactive form group in this situation, so `[formControl]="null"` was not appropriate and was causing type errors.

Please note: Build verification is still facing a persistent environment issue related to '@angular-devkit/build-angular'. The changes I've made specifically address the SCSS and template compilation errors you reported.